### PR TITLE
Propagates TrackInfo updates as UPnP Event

### DIFF
--- a/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
+++ b/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
@@ -18,6 +18,7 @@ import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Logger;
 import org.rpi.mplayer.TrackInfo;
 import org.rpi.utils.Utils;
@@ -380,7 +381,13 @@ public class ChannelBase {
         try {
             DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
             DocumentBuilder builder = factory.newDocumentBuilder();
-            InputSource insrc = new InputSource(new StringReader(metadata.trim()));
+            String textToParse = null;
+            if (StringUtils.isAllBlank(metatext)) {
+            	textToParse = metadata;
+            } else {
+            	textToParse = metatext;
+            }
+            InputSource insrc = new InputSource(new StringReader(textToParse));
             return builder.parse(insrc);
         } catch (Exception e) {
 

--- a/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
+++ b/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
@@ -234,7 +234,8 @@ public class ChannelBase {
             for(int i = 0; i < resList.getLength(); i++ )
             {
             	Node resNode = resList.item(i);
-            	if (resNode.getAttributes().getNamedItem("protocolInfo").getTextContent().contains(":audio/")) {
+            	if (resNode.getAttributes().getNamedItem("protocolInfo") != null && 
+            			resNode.getAttributes().getNamedItem("protocolInfo").getTextContent().contains(":audio/")) {
             		audioResource = (Element) resList.item(i);
             		break;
             	}

--- a/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
+++ b/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
@@ -245,9 +245,16 @@ public class ChannelBase {
             	itemList.appendChild(audioResource);
             	audioResource.setAttribute("protocolInfo", "http-get:*:audio/mpeg:DLNA.ORG_PN=MP3;DLNA.ORG_OP=01");
             }
-            audioResource.setAttribute("bitrate", Long.toString(trackInfo.getBitrate()));
-            audioResource.setAttribute("sampleFrequency", Long.toString(trackInfo.getSampleRate()));
-            audioResource.setAttribute("bitsPerSample", Long.toString(trackInfo.getBitDepth()));
+            
+            if (trackInfo.getBitrate() > 0) {
+            	audioResource.setAttribute("bitrate", Long.toString(trackInfo.getBitrate()));
+            }
+            if (trackInfo.getSampleRate() > 0) {
+            	audioResource.setAttribute("sampleFrequency", Long.toString(trackInfo.getSampleRate()));
+            }
+            if (trackInfo.getBitDepth() > 0) {
+            	audioResource.setAttribute("bitsPerSample", Long.toString(trackInfo.getBitDepth()));
+            }
             
             w = xmlDocumentToString(doc);
             return metatext;

--- a/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
+++ b/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
@@ -9,15 +9,20 @@ import java.util.Vector;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerConfigurationException;
+import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.xpath.XPath;
 import javax.xml.xpath.XPathFactory;
 
 import org.apache.log4j.Logger;
+import org.rpi.mplayer.TrackInfo;
 import org.rpi.utils.Utils;
 import org.w3c.dom.Document;
+import org.w3c.dom.Element;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -210,6 +215,55 @@ public class ChannelBase {
         return "";
     }
 
+	public String updateTrackInfo(TrackInfo trackInfo) {
+    	Writer w = null;
+        try {
+            Document doc = getDocument();
+            
+            if (doc.getFirstChild() == null) {
+            	// TODO create empty DIDL-Object
+            	log.warn("no metadata available.");
+            	return "";
+            }
+            
+            Element node = (Element) doc.getFirstChild();
+            Element itemList = (Element) node.getElementsByTagName("item").item(0);
+            NodeList resList = itemList.getElementsByTagName("res");
+            Element audioResource = null;
+            for(int i = 0; i < resList.getLength(); i++ )
+            {
+            	Node resNode = resList.item(i);
+            	if (resNode.getAttributes().getNamedItem("protocolInfo").getTextContent().contains(":audio/")) {
+            		audioResource = (Element) resList.item(i);
+            		break;
+            	}
+            }
+            if (audioResource == null) {
+            	audioResource = doc.createElement("res");
+            	itemList.appendChild(audioResource);
+            	audioResource.setAttribute("protocolInfo", "http-get:*:audio/mpeg:DLNA.ORG_PN=MP3;DLNA.ORG_OP=01");
+            }
+            audioResource.setAttribute("bitrate", Long.toString(trackInfo.getBitrate()));
+            audioResource.setAttribute("sampleFrequency", Long.toString(trackInfo.getSampleRate()));
+            audioResource.setAttribute("bitsPerSample", Long.toString(trackInfo.getBitDepth()));
+            
+            w = xmlDocumentToString(doc);
+            return metatext;
+        } catch (Exception e) {
+            log.error("Error Creating XML Doc", e);
+        }
+        finally {
+        	if(w !=null) {
+        		try {
+					w.close();
+				} catch (IOException e) {
+					log.error("Error closing Writer");
+				}
+        	}
+        }
+        return null;
+	}
+
     public String updateTrack(String title, String artist) {
     	Writer w = null;
         try {
@@ -238,12 +292,7 @@ public class ChannelBase {
                    log.info("ICY INFO Replacing dc:artist: " + artist);
                 }
             }
-            Transformer transformer = TransformerFactory.newInstance().newTransformer();
-            StreamResult result = new StreamResult(new StringWriter());
-            DOMSource source = new DOMSource(doc);
-            transformer.transform(source, result);
-            w = result.getWriter();
-            metatext = w.toString();
+            w = xmlDocumentToString(doc);
             return metatext;
         } catch (Exception e) {
             log.error("Error Creating XML Doc", e);
@@ -260,7 +309,19 @@ public class ChannelBase {
         return null;
     }
 
-    private String tidyUpString(String s) throws Exception {
+	private Writer xmlDocumentToString(Document doc)
+			throws TransformerConfigurationException, TransformerFactoryConfigurationError, TransformerException {
+		Writer w;
+		Transformer transformer = TransformerFactory.newInstance().newTransformer();
+		StreamResult result = new StreamResult(new StringWriter());
+		DOMSource source = new DOMSource(doc);
+		transformer.transform(source, result);
+		w = result.getWriter();
+		metatext = w.toString();
+		return w;
+	}
+
+	private String tidyUpString(String s) throws Exception {
         String string = "";
         if (s.equals(s.toUpperCase())) {
             // s = s.toLowerCase();
@@ -649,7 +710,5 @@ public class ChannelBase {
 	public void setKeepURL(boolean keep_url) {
 		this.keep_url = keep_url;
 	}
-	
-	
 
 }

--- a/com.upnp.mediaplayer/src/org/rpi/mplayer/TrackInfo.java
+++ b/com.upnp.mediaplayer/src/org/rpi/mplayer/TrackInfo.java
@@ -175,4 +175,18 @@ public class TrackInfo extends Observable {
 		return builder.toString();
 	}
 
+	/**
+	 * 
+	 * @return
+	 * 			cloned attribute values 
+	 */
+	public TrackInfo cloneToValueObject() {
+		TrackInfo cloned = new TrackInfo();
+		cloned.bitRate = bitRate;
+		cloned.codec = codec;
+		cloned.depth = depth;
+		cloned.duration = duration;
+		cloned.sampleRate = sampleRate;
+		return cloned;
+	}
 }

--- a/com.upnp.mediaplayer/src/org/rpi/player/PlayManager.java
+++ b/com.upnp.mediaplayer/src/org/rpi/player/PlayManager.java
@@ -48,6 +48,7 @@ import org.rpi.player.events.EventStatusChanged;
 import org.rpi.player.events.EventStopSongcast;
 import org.rpi.player.events.EventTimeUpdate;
 import org.rpi.player.events.EventTrackChanged;
+import org.rpi.player.events.EventUpdateTrackInfo;
 import org.rpi.player.events.EventUpdateTrackMetaText;
 import org.rpi.player.events.EventVolumeChanged;
 import org.rpi.player.observers.*;
@@ -1125,6 +1126,13 @@ public class PlayManager implements Observer {
 			break;
 		case EVENTUPDATETRACKINFO:
 			try {
+				EventUpdateTrackInfo eti = (EventUpdateTrackInfo) e;
+				if (current_track != null) {
+					EventUpdateTrackMetaText etm = new EventUpdateTrackMetaText();
+					String metatext = current_track.updateTrackInfo(eti.getTrackInfo());
+					etm.setMetaText(metatext);
+					obsvInfo.notifyChange(etm);
+				}
 				obsvInfo.notifyChange(e);
 			} catch (Exception eut) {
 				log.error("Error EVENTUPDATETRACKINFO", eut);


### PR DESCRIPTION
Updated TrackInfo informations (bitrate, sample rate, bit depth) are now send to UPnP subscriber (control point's). Updated artist and album informations are preserved by using metatext (if possible) as a template.
