### PR TITLE
Fix UPnP resource encoding characteristics "bitrate" to bytes/s 

### DIFF
--- a/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
+++ b/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
@@ -247,7 +247,9 @@ public class ChannelBase {
             }
             
             if (trackInfo.getBitrate() > 0) {
-            	audioResource.setAttribute("bitrate", Long.toString(trackInfo.getBitrate()));
+				// MPD bitrate is: instantaneous bitrate in kbps
+				// UPnP bitrate is : the bitrate in bytes/second
+            	audioResource.setAttribute("bitrate", Long.toString(trackInfo.getBitrate() * 125 )); // * 1000/8
             }
             if (trackInfo.getSampleRate() > 0) {
             	audioResource.setAttribute("sampleFrequency", Long.toString(trackInfo.getSampleRate()));

--- a/com.upnp.mediaplayer/src/org/rpi/mpdplayer/StatusMonitor.java
+++ b/com.upnp.mediaplayer/src/org/rpi/mpdplayer/StatusMonitor.java
@@ -186,12 +186,6 @@ public class StatusMonitor extends Observable implements Runnable, Observer {
 					String bitrate = res.get("bitrate");
 					try {
 						long br = Long.valueOf(bitrate).longValue();
-						// MPD bitrate is: instantaneous bitrate in kbps
-						// UPnP bitrate should be : the bitrate in bytes/second
-						// of the resource, according to "ContentDirectory:1
-						// Service Template Version 1.01"
-						// @TODO br = br * 1000 / 8;
-						//br = br * 125;
 						ti.setBitrate(br);
 					} catch (Exception e) {
 


### PR DESCRIPTION
I think mediaplayer is using kbit/s as "domain/system bitrate". The conversion of the bitrate should therefore be done at system border when the UPnP event is being generated.