### PR TITLE
Fixed upnp:class

### DIFF
--- a/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
+++ b/com.upnp.mediaplayer/src/org/rpi/channel/ChannelBase.java
@@ -276,7 +276,7 @@ public class ChannelBase {
     public String updateTrack(String title, String artist) {
     	Writer w = null;
         try {
-            String full_title = title + " - " + artist;
+            String full_title = title; // + " - " + artist;
             full_title = tidyUpString(full_title);
             Document doc = getDocument();
             Node node = doc.getFirstChild();
@@ -299,6 +299,9 @@ public class ChannelBase {
                 {
                    n.setTextContent(artist);
                    log.info("ICY INFO Replacing dc:artist: " + artist);
+                }else if(n.getNodeName() == "upnp:class")
+                {
+                   n.setTextContent("object.item.audioItem.musicTrack");
                 }
             }
             w = xmlDocumentToString(doc);


### PR DESCRIPTION
While playing radio-stations updates to album (radio station) and artist doesn't show up.

Switching to *upnp:class* **object.item.audioItem.musicTrack** fixes this issue.

You can check out https://github.com/sf666/nextcp2 if you like.