### PR TITLE
Added support for delivering MPD tags as descMetadata to control point.

### DIFF
--- a/com.upnp.mediaplayer/src/org/rpi/mpdplayer/StatusMonitor.java
+++ b/com.upnp.mediaplayer/src/org/rpi/mpdplayer/StatusMonitor.java
@@ -57,6 +57,12 @@ public class StatusMonitor extends Observable implements Runnable, Observer {
 				log.debug("Song Changed From : " + current_songid + " To: " + value);
 				EventTrackChanged ev = new EventTrackChanged();
 				ev.setMPD_id(value);
+				ev.MUSICBRAINZ_ALBUMARTISTID = res.get("MUSICBRAINZ_ALBUMARTISTID");
+                ev.MUSICBRAINZ_ALBUMID = res.get("MUSICBRAINZ_ALBUMID");
+                ev.MUSICBRAINZ_ARTISTID = res.get("MUSICBRAINZ_ARTISTID");
+                ev.MUSICBRAINZ_RELEASETRACKID = res.get("MUSICBRAINZ_RELEASETRACKID");
+                ev.MUSICBRAINZ_TRACKID = res.get("MUSICBRAINZ_TRACKID");
+                ev.MUSICBRAINZ_WORKID = res.get("MUSICBRAINZ_WORKID");
 				fireEvent(ev);
 				current_songid = value;
 				sentFinishingEvent = false;

--- a/com.upnp.mediaplayer/src/org/rpi/player/PlayManager.java
+++ b/com.upnp.mediaplayer/src/org/rpi/player/PlayManager.java
@@ -1183,6 +1183,7 @@ public class PlayManager implements Observer {
 		case EVENTTRACKCHANGED:
 			EventTrackChanged etc = (EventTrackChanged) e;
 			current_track = etc.getTrack();
+            obsvInfo.notifyChange(etc);			
 			break;
 		case EVENTVOLUMECHANGED:
 			try {

--- a/com.upnp.mediaplayer/src/org/rpi/player/events/EventTrackChanged.java
+++ b/com.upnp.mediaplayer/src/org/rpi/player/events/EventTrackChanged.java
@@ -40,6 +40,17 @@ public class EventTrackChanged implements EventBase {
 
 	private ChannelBase track = null;
 
+	// MusicBrainz tag support
+	
+	public String MUSICBRAINZ_TRACKID = "";
+	
+	public String MUSICBRAINZ_ALBUMID = "";
+	
+	public String MUSICBRAINZ_ARTISTID = "";
+	
+	public String MUSICBRAINZ_WORKID = "";
+	
+	public String MUSICBRAINZ_RELEASETRACKID = "";
 
-
+	public String MUSICBRAINZ_ALBUMARTISTID = "";
 }

--- a/com.upnp.mediaplayer/src/org/rpi/providers/PrvAVTransport.java
+++ b/com.upnp.mediaplayer/src/org/rpi/providers/PrvAVTransport.java
@@ -295,7 +295,7 @@ public class PrvAVTransport extends DvProviderUpnpOrgAVTransport1 implements Obs
 			String m_track_metadata_html = ""; 
 			if (track != null) {
 				m_uri = track.getUri();
-				m_metadata = track.getMetadata();
+				m_metadata = track.updateTrackChange(ec);
 				m_track_metadata_html = stringToHTMLString(m_metadata);
 				if ((!(m_uri.equalsIgnoreCase(track_uri)) || (!m_metadata.equalsIgnoreCase(track_metadata))) || (!m_track_metadata_html.equalsIgnoreCase(track_metadata_html))) {
 					track_uri = m_uri;


### PR DESCRIPTION
Hi there,

I've added support for propagating MPD tags (right now the musicBrainzID tags) to the UPnP control point. Those tags are included into the item desc metadata section of the AVControlpoint event. It would be nice if you would integrate this into the master branch.
