### PR TITLE
Fix broken ohNet library selection caused by previous commit

### DIFF
--- a/com.upnp.mediaplayer/lib/application/run.sh
+++ b/com.upnp.mediaplayer/lib/application/run.sh
@@ -29,7 +29,7 @@ case $ARCH in
     ARCH="amd64"
 esac
 echo "$ARCH"
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SCRIPTPATH/mediaplayer_lib/ohNet/linux/$arch
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SCRIPTPATH/mediaplayer_lib/ohNet/linux/$ARCH
 echo Java LibPath: $LD_LIBRARY_PATH
 java -jar $SCRIPTPATH/mediaplayer.jar &
 _wlanexist=$(ifconfig | grep wlan) || true

--- a/com.upnp.mediaplayer/lib/application/scripts/mediaplayer.sh
+++ b/com.upnp.mediaplayer/lib/application/scripts/mediaplayer.sh
@@ -31,6 +31,6 @@ case $ARCH in
     ARCH="amd64"
 esac
 echo "$ARCH"
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MEDIAPLAYER_DIR/mediaplayer_lib/ohNet/linux/$arch
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$MEDIAPLAYER_DIR/mediaplayer_lib/ohNet/linux/$ARCH
 echo Java LibPath: $LD_LIBRARY_PATH
 exec java -jar mediaplayer.jar

--- a/com.upnp.mediaplayer/lib/application/scripts/systemd/run_systemd.sh
+++ b/com.upnp.mediaplayer/lib/application/scripts/systemd/run_systemd.sh
@@ -33,5 +33,6 @@ case $ARCH in
     ARCH="amd64"
 esac
 echo "$ARCH"
-export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SCRIPTPATH/mediaplayer_lib/ohNet/linux/$arch
+export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$SCRIPTPATH/mediaplayer_lib/ohNet/linux/$ARCH
+echo Java LibPath: $LD_LIBRARY_PATH
 java -jar "${SCRIPTPATH}"/mediaplayer.jar > /dev/null &


### PR DESCRIPTION
Just spotted that I left the ohNet library selection mechanism broken when I changed the variable name in the last commit. That'll teach me to copy and paste code in a hurry without testing! 😮 Luckily there doesn't seem to have been a release since my last commit.

I've tested it this time and it works as it should.

I've also synced all 3 scripts so that the systemd version also echos the java lib path, the same as the other two scripts.